### PR TITLE
Fix build with other release number (HPC-7281)

### DIFF
--- a/bdist_rpm.sh
+++ b/bdist_rpm.sh
@@ -1,19 +1,15 @@
 #!/bin/bash
 
 PACKAGE=slurm-spank-talamini
+GITTAG=$(git log --format=%ct.%h -1)
 VERSION=$(grep "Version:.*[0-9]" ${PACKAGE}.spec | tr -s " " |  awk '{print $2;}')
 RELEASE=$(grep "%global rel.*[-1-9]" ${PACKAGE}.spec | tr -s " " | awk '{print $3}')
 
-if [ "${RELEASE}" -gt 1 ]; then
-    SUFFIX=${VERSION}-${RELEASE}
-else
-    SUFFIX=${VERSION}
-fi
+SUFFIX=${VERSION}-${RELEASE}
 
-GITTAG=$(git log --format=%ct.%h -1)
 
 mkdir -p BUILD SOURCES SPECS RPMS BUILDROOT
-git archive --format=tar.gz -o "SOURCES/${PACKAGE}-${SUFFIX}.tar.gz" --prefix="${PACKAGE}-${SUFFIX}/" HEAD
+git archive --format=tar.gz -o "SOURCES/${PACKAGE}-${SUFFIX}.tar.gz" --prefix="${PACKAGE}-${VERSION}/" HEAD
 cp ${PACKAGE}.spec "SPECS"
 rpmbuild --define "gittag ${GITTAG}" --define "_topdir $PWD" -ba SPECS/${PACKAGE}.spec
 rm -rf BUILD SOURCES BUILDROOT SPECS

--- a/slurm-spank-talamini.spec
+++ b/slurm-spank-talamini.spec
@@ -3,11 +3,11 @@
 Summary: Slurm SPANK plugins developed by HPCUGent
 Name: slurm-spank-talamini
 Version: 0.0.1
-%global rel	1
-Release: %{rel}%{gittag}%{?dist}.ug
+%global rel	2
+Release: %{rel}.%{gittag}%{?dist}.ug
 License: GPL
 Group: System Environment/Base
-Source0: %{name}-%{version}.tar.gz
+Source0: %{name}-%{version}-%{rel}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: slurm-devel
 Requires: slurm


### PR DESCRIPTION
Needed to build against 19.05, and get the correct version set.